### PR TITLE
Bugfix in generating the kernel when the direct dimension has units of ppm.

### DIFF
--- a/docs/notebooks/auto_examples/MAF/plot_2D_0_Rb2O2p25SiO2.ipynb
+++ b/docs/notebooks/auto_examples/MAF/plot_2D_0_Rb2O2p25SiO2.ipynb
@@ -263,7 +263,7 @@
       },
       "outputs": [],
       "source": [
-        "# setup the pre-defined range of alpha and lambda values\nlambdas = 10 ** (-5.2 - 0.35 * (np.arange(5) / 4))\nalphas = 10 ** (-5.5 - 1.25 * (np.arange(5) / 4))\n\n# setup the smooth lasso cross-validation class\ns_lasso = SmoothLassoCV(\n    alphas=alphas,  # A numpy array of alpha values.\n    lambdas=lambdas,  # A numpy array of lambda values.\n    sigma=0.0045,  # The standard deviation of noise from the 2D MAF data.\n    folds=10,  # The number of folds in n-folds cross-validation.\n    inverse_dimension=inverse_dimensions,  # previously defined inverse dimensions.\n    verbose=1,  # If non-zero, prints the progress as the computation proceeds.\n)\n\n# run the fit method on the compressed kernel and compressed data.\ns_lasso.fit(K=compressed_K, s=compressed_s)"
+        "# setup the pre-defined range of alpha and lambda values\nlambdas = 10 ** (-5.2 - 1.25 * (np.arange(5) / 4))\nalphas = 10 ** (-5.5 - 1.25 * (np.arange(5) / 4))\n\n# setup the smooth lasso cross-validation class\ns_lasso = SmoothLassoCV(\n    alphas=alphas,  # A numpy array of alpha values.\n    lambdas=lambdas,  # A numpy array of lambda values.\n    sigma=0.0045,  # The standard deviation of noise from the 2D MAF data.\n    folds=10,  # The number of folds in n-folds cross-validation.\n    inverse_dimension=inverse_dimensions,  # previously defined inverse dimensions.\n    verbose=1,  # If non-zero, prints the progress as the computation proceeds.\n)\n\n# run the fit method on the compressed kernel and compressed data.\ns_lasso.fit(K=compressed_K, s=compressed_s)"
       ]
     },
     {

--- a/examples/MAF/plot_2D_0_Rb2O2p25SiO2.py
+++ b/examples/MAF/plot_2D_0_Rb2O2p25SiO2.py
@@ -209,7 +209,7 @@ print(f"truncation_index = {new_system.truncation_index}")
 # increase the grid resolution for your problem if desired.
 
 # setup the pre-defined range of alpha and lambda values
-lambdas = 10 ** (-5.2 - 0.35 * (np.arange(5) / 4))
+lambdas = 10 ** (-5.2 - 1.25 * (np.arange(5) / 4))
 alphas = 10 ** (-5.5 - 1.25 * (np.arange(5) / 4))
 
 # setup the smooth lasso cross-validation class

--- a/mrinversion/__init__.py
+++ b/mrinversion/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.1.0"
+__version__ = "0.1.1.dev0"

--- a/mrinversion/kernel/csa_aniso.py
+++ b/mrinversion/kernel/csa_aniso.py
@@ -72,18 +72,12 @@ class ShieldingPALineshape(LineShape):
 
         x_csdm = self.inverse_kernel_dimension[0]
         if x_csdm.coordinates.unit.physical_type == "frequency":
-
-            # larmor frequency from method.
-            B0 = method.spectral_dimensions[0].events[0].magnetic_flux_density  # in T
-            gamma = method.channels[0].gyromagnetic_ratio  # in MHz/T
-            larmor_frequency = -gamma * B0  # in MHz
-
             # convert zeta to ppm if given in frequency units.
-            zeta /= larmor_frequency  # zeta in ppm
+            zeta /= self.larmor_frequency  # zeta in ppm
 
             for dim_i in self.inverse_kernel_dimension:
                 if dim_i.origin_offset.value == 0:
-                    dim_i.origin_offset = f"{abs(larmor_frequency)} MHz"
+                    dim_i.origin_offset = f"{abs(self.larmor_frequency)} MHz"
 
         spin_systems = [
             SpinSystem(
@@ -91,10 +85,6 @@ class ShieldingPALineshape(LineShape):
             )
             for z, e in zip(zeta, eta)
         ]
-
-        dim = method.spectral_dimensions[0]
-        if dim.origin_offset == 0:
-            dim.origin_offset = larmor_frequency * 1e6  # in Hz
 
         sim = Simulator()
         sim.config.number_of_sidebands = self.number_of_sidebands

--- a/mrinversion/kernel/tests/shielding_lineshape_kernel_test.py
+++ b/mrinversion/kernel/tests/shielding_lineshape_kernel_test.py
@@ -11,8 +11,32 @@ from mrinversion.kernel.nmr import ShieldingPALineshape
 from mrinversion.kernel.nmr import SpinningSidebands
 from mrinversion.linear_model import TSVDCompression
 
-anisotropic_dimension = [
+anisotropic_dimension_Hz_complex_fft = [
     cp.Dimension(type="linear", count=96, increment="208.33 Hz", complex_fft=True)
+]
+
+anisotropic_dimension_Hz = [
+    cp.Dimension(
+        type="linear", count=96, increment="208.33 Hz", coordinates_offset="-9999.84 Hz"
+    )
+]
+anisotropic_dimension_ppm_complex_fft = cp.Dimension(
+    type="linear", count=96, increment="2.618010581236476 ppm", complex_fft=True
+)
+
+
+anisotropic_dimension_ppm = cp.Dimension(
+    type="linear",
+    count=96,
+    increment="2.618010581236476 ppm",
+    coordinates_offset="-125.6645078993509 ppm",
+)
+
+anisotropic_dims = [
+    anisotropic_dimension_Hz_complex_fft,
+    anisotropic_dimension_Hz,
+    anisotropic_dimension_ppm_complex_fft,
+    anisotropic_dimension_ppm,
 ]
 
 inverse_dimension = [
@@ -63,120 +87,124 @@ def generate_shielding_kernel(zeta_, eta_, angle, freq, n_sidebands, to_ppm=True
 
 
 def test_zeta_eta_from_x_y():
-    ns_obj = ShieldingPALineshape(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-        rotor_angle="90 deg",
-        rotor_frequency="14 kHz",
-        number_of_sidebands=1,
-    )
+    for dim in anisotropic_dims:
+        ns_obj = ShieldingPALineshape(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+            rotor_angle="90 deg",
+            rotor_frequency="14 kHz",
+            number_of_sidebands=1,
+        )
 
-    x = np.arange(4) * 3000
-    y = np.arange(4) * 3000
-    factor_ = 4 / np.pi
-    zeta_ = []
-    eta_ = []
-    for y_ in y:
-        for x_ in x:
-            z = np.sqrt(x_ ** 2 + y_ ** 2)
-            if x_ < y_:
-                eta_.append(factor_ * np.arctan(x_ / y_))
-                zeta_.append(z)
-            elif x_ > y_:
-                eta_.append(factor_ * np.arctan(y_ / x_))
-                zeta_.append(-z)
-            else:
-                zeta_.append(z)
-                eta_.append(1.0)
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        x = np.arange(4) * 3000
+        y = np.arange(4) * 3000
+        factor_ = 4 / np.pi
+        zeta_ = []
+        eta_ = []
+        for y_ in y:
+            for x_ in x:
+                z = np.sqrt(x_ ** 2 + y_ ** 2)
+                if x_ < y_:
+                    eta_.append(factor_ * np.arctan(x_ / y_))
+                    zeta_.append(z)
+                elif x_ > y_:
+                    eta_.append(factor_ * np.arctan(y_ / x_))
+                    zeta_.append(-z)
+                else:
+                    zeta_.append(z)
+                    eta_.append(1.0)
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
 
-    assert np.allclose(zeta, np.asarray(zeta_))
-    assert np.allclose(eta, np.asarray(eta_))
+        assert np.allclose(zeta, np.asarray(zeta_))
+        assert np.allclose(eta, np.asarray(eta_))
 
 
 def test_MAF_lineshape_kernel():
-    ns_obj = ShieldingPALineshape(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-        rotor_angle="90 deg",
-        rotor_frequency="14 kHz",
-        number_of_sidebands=1,
-    )
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
-    print("zeta", zeta.size, "eta", eta.size)
-    K = ns_obj.kernel(supersampling=1)
-    sim_lineshape = generate_shielding_kernel(zeta, eta, np.pi / 2, 14000, 1).T
-    assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
+    for dim in anisotropic_dims:
+        ns_obj = ShieldingPALineshape(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+            rotor_angle="90 deg",
+            rotor_frequency="14 kHz",
+            number_of_sidebands=1,
+        )
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        K = ns_obj.kernel(supersampling=1)
+        sim_lineshape = generate_shielding_kernel(zeta, eta, np.pi / 2, 14000, 1).T
+        assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
 
-    ns_obj = MAF(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-    )
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
-    K = ns_obj.kernel(supersampling=1)
-    sim_lineshape = generate_shielding_kernel(zeta, eta, np.pi / 2, 14000, 1).T
+        ns_obj = MAF(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+        )
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        K = ns_obj.kernel(supersampling=1)
+        sim_lineshape = generate_shielding_kernel(zeta, eta, np.pi / 2, 14000, 1).T
 
-    assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
+        assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
 
-    _ = TSVDCompression(K, s=np.arange(96))
-    assert _.truncation_index == 15
+        _ = TSVDCompression(K, s=np.arange(96))
+        assert _.truncation_index == 15
 
 
 def test_spinning_sidebands_kernel():
     # 1
-    ns_obj = ShieldingPALineshape(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-        rotor_angle="54.735 deg",
-        rotor_frequency="100 Hz",
-        number_of_sidebands=96,
-    )
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
-    K = ns_obj.kernel(supersampling=1)
-    sim_lineshape = generate_shielding_kernel(zeta, eta, 0.9553059660790962, 100, 96).T
+    for dim in anisotropic_dims:
+        ns_obj = ShieldingPALineshape(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+            rotor_angle="54.735 deg",
+            rotor_frequency="100 Hz",
+            number_of_sidebands=96,
+        )
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        K = ns_obj.kernel(supersampling=1)
+        sim_lineshape = generate_shielding_kernel(
+            zeta, eta, 0.9553059660790962, 100, 96
+        ).T
 
-    assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
+        assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
 
-    # 2
-    ns_obj = ShieldingPALineshape(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension_ppm,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-        rotor_angle="54.735 deg",
-        rotor_frequency="100 Hz",
-        number_of_sidebands=96,
-    )
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
-    K = ns_obj.kernel(supersampling=1)
-    sim_lineshape = generate_shielding_kernel(
-        zeta, eta, 0.9553059660790962, 100, 96, to_ppm=False
-    ).T
+        # 2
+        ns_obj = ShieldingPALineshape(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension_ppm,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+            rotor_angle="54.735 deg",
+            rotor_frequency="100 Hz",
+            number_of_sidebands=96,
+        )
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        K = ns_obj.kernel(supersampling=1)
+        sim_lineshape = generate_shielding_kernel(
+            zeta, eta, 0.9553059660790962, 100, 96, to_ppm=False
+        ).T
 
-    assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
+        assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
 
-    # 3
-    ns_obj = SpinningSidebands(
-        anisotropic_dimension=anisotropic_dimension,
-        inverse_dimension=inverse_dimension,
-        channel="29Si",
-        magnetic_flux_density="9.4 T",
-    )
-    zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
-    K = ns_obj.kernel(supersampling=1)
-    sim_lineshape = generate_shielding_kernel(
-        zeta, eta, 0.9553059660790962, 208.33, 96
-    ).T
+        # 3
+        ns_obj = SpinningSidebands(
+            anisotropic_dimension=dim,
+            inverse_dimension=inverse_dimension,
+            channel="29Si",
+            magnetic_flux_density="9.4 T",
+        )
+        zeta, eta = ns_obj._get_zeta_eta(supersampling=1)
+        K = ns_obj.kernel(supersampling=1)
+        sim_lineshape = generate_shielding_kernel(
+            zeta, eta, 0.9553059660790962, 208.33, 96
+        ).T
 
-    assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
+        assert np.allclose(K, sim_lineshape, rtol=1.0e-3, atol=1e-3)
 
-    _ = TSVDCompression(K, s=np.arange(96))
-    assert _.truncation_index == 15
+        _ = TSVDCompression(K, s=np.arange(96))
+        assert _.truncation_index == 15


### PR DESCRIPTION
When generating the CSA line shape kernel, the ``anisotropic_dimension`` argument is a csdm object with frequency dimensionality. In case the csdm object has units of ppm, the generated kernel is incorrect. This PR fixes this issue.

- [x] When the csdm object has units of ppm, convert it to units of frequency by multiplying the dimension with the Larmor frequency. The Larmor frequency is the product of the negative gyromagnetic ratio of the nucleus and the macroscopic external magnetic field, both of which are the input arguments of the ``ShieldingPALineshape`` class.